### PR TITLE
Add integration with codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
 language: generic
 
 before_script:
-  - pip install --user codecov && codecov
+  - gem install codecov
+  - git clone https://github.com/albfan/bashcov.git
+  - cd bashcov/
+  - git checkout debug
+  - gem build bashcov.gemspec
+  - gem install bashcov-1.2.1.gem
+  - cd ..
+  - rm -rf bashcov/
+  - export PATH=$PATH:$PWD
+
+script:
+   - pwd
+   - ls
+   - bashcov -r codecov:SimpleCov::Formatter::Codecov -- script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: generic
 
 before_script:
-  - gem install codecov
   - git clone https://github.com/albfan/bashcov.git
   - cd bashcov/
   - git checkout debug
@@ -9,9 +8,8 @@ before_script:
   - gem install bashcov-1.2.1.gem
   - cd ..
   - rm -rf bashcov/
+  - gem install codecov
   - export PATH=$PATH:$PWD
 
 script:
-   - pwd
-   - ls
-   - bashcov -r codecov:SimpleCov::Formatter::Codecov -- script.sh
+   - bash <(curl -s https://codecov.io/bash)

--- a/script.sh
+++ b/script.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 a_function(){
     echo "$1"
     if [ "$1" = "1" ];
@@ -16,3 +18,12 @@ then
 else
     echo "missed"
 fi
+
+DATA="something"
+
+cat << EOF
+Code detect as
+   executed
+   $DATA
+EOF
+


### PR DESCRIPTION
resolves #1 

https://codecov.io/github/albfan/example-bash
https://travis-ci.org/albfan/example-bash

See 

<pre>
  - git clone https://github.com/albfan/bashcov.git
  - cd bashcov/
  - gem build bashcov.gemspec
  - gem install bashcov-1.2.1.gem
</pre>


is a patch meanwhile PR is accepted

Anyway I found a common problem on your system. It caches too much and doesn't realize HEAD was rebased.

if you issue:

```
$ bashcov ./script.sh
$ firefox coverage/index.html
```

you will see a coverage of 87%

![image](https://cloud.githubusercontent.com/assets/220968/10437301/6df54456-712c-11e5-9456-08ebe261ff1f.png)

Don't know how to refresh code. (See actual .travis.yml remove bashcov gem compilation and codecov shows it as if exists)   
