### PR TITLE
Show internals of bash coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
 language: generic
 
 before_script:
-  - pip install --user codecov && codecov
+  - gem install codecov
+  - git clone https://github.com/albfan/bashcov.git
+  - cd bashcov/
+  - git checkout debug
+  - gem build bashcov.gemspec
+  - gem install bashcov-1.2.1.gem
+  - cd ..
+  - rm -rf bashcov/
+  - export PATH=$PATH:$PWD
+
+script:
+   - pwd
+   - ls
+   - bashcov -r codecov:SimpleCov::Formatter::Codecov -- script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: generic
 
 before_script:
-  - gem install codecov
   - git clone https://github.com/albfan/bashcov.git
   - cd bashcov/
   - git checkout debug
@@ -9,9 +8,8 @@ before_script:
   - gem install bashcov-1.2.1.gem
   - cd ..
   - rm -rf bashcov/
+  - gem install codecov
   - export PATH=$PATH:$PWD
 
 script:
-   - pwd
-   - ls
-   - bashcov -r codecov:SimpleCov::Formatter::Codecov -- script.sh
+   - bash <(curl -s https://codecov.io/bash)

--- a/debug_script.sh
+++ b/debug_script.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+echo
+echo define parseable prompt for bash debug
+export PS4='%(+CODECOV$(cd $(dirname ${BASH_SOURCE[0]}); pwd)/$(basename ${BASH_SOURCE[0]})/${LINENO}: )'
+echo PS4 = $PS4
+
+echo
+echo "debug script (-x), get only the debug output"
+bash -x script.sh |& sed -n /^%\(+CODECOV/p | sort -t: -k1
+
+echo 
+echo "code coverage report:"
+bash -x script.sh |& sed -n /^%\(+CODECOV/p | cut -d: -f1 | sort | uniq -c
+
+echo
+echo As you can see, line 24 executed is the start for a here document. So all lines till is EOF word are really covered
+cat -n script.sh | tail 
+echo
+echo parser should notice that and add those lines to covered ones.
+tail -n+24 script.sh | sed 's/^/\t1 %(+CODECOV... /'

--- a/script.sh
+++ b/script.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 a_function(){
     echo "$1"
     if [ "$1" = "1" ];
@@ -16,3 +18,12 @@ then
 else
     echo "missed"
 fi
+
+DATA="something"
+
+cat << EOF
+Code detect as
+   executed
+   $DATA
+EOF
+


### PR DESCRIPTION
This is a work in progress to add support on codecov to bash language
- Added here documents to script.sh
- Show working implementation of bash coverage with bashcov (to take references)
- Added failed upload with global codecov uploader
- Added script to show main concepts about bash debug and its use to provide code coverage report
