### PR TITLE
Move coverage.json file to coverage.xml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
         with:
           fail_ci_if_error: true
-          file: coverage/codecov-result.json
+          file: coverage/coverage.xml

--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,5 @@
 require 'simplecov'
 require 'simplecov-cobertura'
 
+# Creates a `coverage/coverage.xml` file
 SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter


### PR DESCRIPTION
The `CoberturaFormatter` creates a `coverage.xml` file and not a `coverage.json` file.

This PR just updates the example to be a little more clear.